### PR TITLE
Set up error-chain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,4 +11,4 @@ rustc-serialize = "0.3.19"
 log = "0.3"
 env_logger = "0.3"
 csv = "0.14.7"
-error-chain = "0.6.2"
+error-chain = { version = "0.7.0", git = "https://github.com/brson/error-chain", branch = "fixes" }

--- a/src/bench.rs
+++ b/src/bench.rs
@@ -1,10 +1,10 @@
+use errors::*;
 use git;
 use regex;
 use std::env;
-use std::error::Error;
 use std::process::Command;
 
-pub fn bench(options: &[String]) -> Result<(), Box<Error>> {
+pub fn bench(options: &[String]) -> Result<()> {
     let current_dir = env::current_dir()?;
     let repo = git::open_repo(&current_dir)?;
     

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,7 +1,7 @@
 error_chain! {
     foreign_links {
         Io(::std::io::Error);
-        Git2(::git2::Git2Error);
+        Git2(::git2::Error);
     }
 
     errors {
@@ -14,6 +14,9 @@ error_chain! {
 
 macro_rules! throw {
     ($e:expr) => {
-        return Err($expr.into());
-    }
+        return Err($e.into());
+    };
+    ($fmt:expr, $($arg:tt)+) => {
+        return Err(format!($fmt, $($arg)+).into());
+    };
 }

--- a/src/git.rs
+++ b/src/git.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 use std::path::Path;
 use git2::{Commit, Error as Git2Error, ErrorCode, Object, Repository, Status,
            STATUS_IGNORED};
-use errors::{ErrorKind, Result};
+use errors::*;
 
 /// Search upwards from `start_path` to find a valid git repo.
 pub fn open_repo(cargo_path: &Path) -> Result<Repository> {
@@ -33,10 +33,8 @@ pub fn open_repo(cargo_path: &Path) -> Result<Repository> {
 }
 
 pub fn check_clean(repo: &Repository) -> Result<()> {
-    let statuses = match repo.statuses(None) {
-        Ok(s) => s,
-        Err(err) => throw!("could not load git repository status: {}", err),
-    };
+    let statuses = repo.statuses(None)
+        .chain_err(|| "could not load git repository status")?;
 
     let mut errors = 0;
     let dirty_status = Status::all() - STATUS_IGNORED;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-extern crate cargo_metro;
+extern crate cargo_chrono;
 
 fn main() {
-    cargo_metro::main();
+    cargo_chrono::main();
 }


### PR DESCRIPTION
@nikomatsakis I fixed this up to use the error chain in [this PR](https://github.com/brson/error-chain/pull/75) and got it compiling. I expanded the throw macro to take fmt arguments as well and it is indeed pretty cool. I don't know about the word 'throw', but I think this macro should be in error-chain.

cc @Yamakaky this project contains an interesting `throw!` macro that removes some of the boilerplate of creating a new error.