### PR TITLE
Update to current git2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ description = "Cargo tool to benchmark multiple commits and generate plots of th
 
 [dependencies]
 docopt = "0.8"
-git2 = "0.6"
+git2 = { version = "0.13.5", default-features = false }
 regex = "0.2"
 rustc-serialize = "0.3.19"
 log = "0.3"

--- a/src/git.rs
+++ b/src/git.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
-use git2::{Commit, Object, Repository, Status, STATUS_IGNORED};
+use git2::{Commit, Object, Repository, Status};
 use git2::build::CheckoutBuilder;
 use errors::*;
 
@@ -25,7 +25,7 @@ pub fn check_clean(repo: &Repository, exceptions: &[PathBuf]) -> Result<()> {
         None => throw!("bare repositories are not supported"),
     };
     let mut errors = 0;
-    let dirty_status = Status::all() - STATUS_IGNORED;
+    let dirty_status = Status::all() - Status::IGNORED;
     for status in statuses.iter() {
         if status.status().intersects(dirty_status) {
             let stderr = io::stderr();


### PR DESCRIPTION
Update for API changes in the git2 crate.

Disable default feaures in git2, since this doesn't need remote support.